### PR TITLE
wordpress-lamp: Minor fixes

### DIFF
--- a/wordpress-lamp_ubuntu1804/playbook.yml
+++ b/wordpress-lamp_ubuntu1804/playbook.yml
@@ -14,7 +14,7 @@
 
     - name: Install LAMP Packages
       apt: name={{ item }} update_cache=yes state=latest
-      loop: [ 'apache2', 'mysql-server', 'python3-pymysql', 'php', 'php-mysql', 'libapache2-mod-php' ]
+      loop: [ 'apache2', 'mysql-server', 'python3-pymysql', 'python-pymysql', 'php', 'php-mysql', 'libapache2-mod-php' ]
       tags: [ system ]
 
     - name: Install PHP Extensions

--- a/wordpress-lamp_ubuntu1804/playbook.yml
+++ b/wordpress-lamp_ubuntu1804/playbook.yml
@@ -69,6 +69,7 @@
         state: absent
         login_user: root
         login_password: "{{ mysql_root_password }}"
+        login_unix_socket: /var/run/mysqld/mysqld.sock
       tags: [ mysql ]
 
     - name: Remove the MySQL test database
@@ -77,6 +78,7 @@
         state: absent
         login_user: root
         login_password: "{{ mysql_root_password }}"
+        login_unix_socket: /var/run/mysqld/mysqld.sock
       tags: [ mysql ]
 
     - name: Creates database for WordPress
@@ -85,6 +87,7 @@
         state: present
         login_user: root
         login_password: "{{ mysql_root_password }}"
+        login_unix_socket: /var/run/mysqld/mysqld.sock
       tags: [ mysql ]
 
     - name: Create MySQL user for WordPress
@@ -95,6 +98,7 @@
         state: present
         login_user: root
         login_password: "{{ mysql_root_password }}"
+        login_unix_socket: /var/run/mysqld/mysqld.sock
       tags: [ mysql ]
 
   # UFW Configuration

--- a/wordpress-lamp_ubuntu1804/playbook.yml
+++ b/wordpress-lamp_ubuntu1804/playbook.yml
@@ -14,7 +14,7 @@
 
     - name: Install LAMP Packages
       apt: name={{ item }} update_cache=yes state=latest
-      loop: [ 'apache2', 'mysql-server', 'python3-pymysql', 'python-pymysql', 'php', 'php-mysql', 'libapache2-mod-php' ]
+      loop: [ 'apache2', 'mysql-server', 'python3-pymysql', 'python-pymysql', 'php', 'php-mysql', 'libapache2-mod-php', 'ufw' ]
       tags: [ system ]
 
     - name: Install PHP Extensions


### PR DESCRIPTION
Adds missing python-pymsql package, fix missing dependency `ufw` and adds missing `login_unix_socket` field where needed. Tested on a Debian 9 server.