### PR TITLE
chore: restart ssh after config update

### DIFF
--- a/setup_ubuntu1804/playbook.yml
+++ b/setup_ubuntu1804/playbook.yml
@@ -48,6 +48,11 @@
         regexp: '^#?PermitRootLogin'
         line: 'PermitRootLogin prohibit-password'
 
+    - name: Restart ssh service
+      service:
+        name: ssh
+        state: restarted
+
 # Install Packages
     - name: Update apt
       apt: update_cache=yes


### PR DESCRIPTION
It seems we need to restart ssh service to apply `/etc/ssh/sshd_config` changes.